### PR TITLE
Fix typo?

### DIFF
--- a/ftdetect/snakemake.vim
+++ b/ftdetect/snakemake.vim
@@ -3,11 +3,11 @@
 " Last Change:	2016 Aug 19
 "
 
-autogroup snakemake_syntax
+augroup snakemake_syntax
     au BufNewFile,BufRead Snakefile set filetype=snakemake
     au BufNewFile,BufRead *.rules set filetype=snakemake
     au BufNewFile,BufRead *.snakefile set filetype=snakemake
     au BufNewFile,BufRead *.snake set filetype=snakemake
 
     autocmd FileType snakemake setlocal commentstring=#\ %s
-autogroup END
+augroup END


### PR DESCRIPTION
Not sure if it's just my editor (neovim) or this was a real typo, but using `autogroup` gave me

```
Error detected while processing $HOME/.vim/bundle/vim-snakemake/ftdetect/snakemake.vim:
line    6:
E492: Not an editor command: autogroup snakemake_syntax
line   13:
E492: Not an editor command: autogroup END
```

Simple change to `augroup` in two places.